### PR TITLE
Implement camera permission overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ npm install
 npm run dev
 ```
 
+When opened in a browser, the page immediately requests camera access on a black
+background. Once permission is granted, the device camera starts and the text
+"Untitled Emotions" appears over the video feed.
+
 ### Requirements
 Use Node.js version listed in `.nvmrc`.
 

--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,9 @@
   <meta charset="UTF-8" />
   <title>Untitled Emotions AR</title>
 </head>
-<body>
-  <video id="video" autoplay playsinline></video>
+<body style="background:black;margin:0;">
+  <div id="overlay" style="display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);color:white;font-family:sans-serif;font-size:2em;">Untitled Emotions</div>
+  <video id="video" autoplay playsinline style="width:100%;height:100%;object-fit:cover;"></video>
   <canvas id="canvas"></canvas>
   <script type="module" src="/dist/main.js"></script>
 </body>

--- a/src/detection.ts
+++ b/src/detection.ts
@@ -1,8 +1,10 @@
 export async function startDetection(video: HTMLVideoElement) {
+  const overlay = document.getElementById('overlay') as HTMLElement | null;
   try {
     const stream = await navigator.mediaDevices.getUserMedia({ video: true });
     video.srcObject = stream;
     await video.play();
+    if (overlay) overlay.style.display = 'block';
   } catch (err) {
     console.error('Camera start failed', err);
   }


### PR DESCRIPTION
## Summary
- request the camera immediately when opening the page
- show an overlay with "Untitled Emotions" after permission is granted
- document the new behavior in the README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: eslint missing parser)*

------
https://chatgpt.com/codex/tasks/task_e_68794856d3fc832e9328c00fa486b13b